### PR TITLE
Allow optional auxiliary_fields in each file

### DIFF
--- a/diag_table_source.yaml
+++ b/diag_table_source.yaml
@@ -51,6 +51,8 @@ global_defaults:
 # field section:
     module_name: ocean_model
     field_name:  # set via keys in the fields section of the diag_table section below
+    auxiliary_fields:  # auxiliary fields to be included with every field. This can also be set per category or per field below
+    #     area_t:
     output_name:  # same as field_name unless overridden
     # file_name:  # same as file_name in file section above unless overridden in diag_table section below
     time_sampling: all  # Currently not used.  Please use the string "all".
@@ -218,6 +220,8 @@ diag_table:
             file_name_dimension: 2d  # descriptor for filename, e.g. 3d, 2d, scalar
             output_freq: 1  # integer: output sampling frequency in output_freq_units (0: every timestep; -1: only at end of run)
             output_freq_units: months  # time units for output: years, months, days, hours, minutes, or seconds
+            auxiliary_fields:  # auxiliary fields to be included with every field in this category
+            #     area_t:
         fields:
             agm:
             aredi:
@@ -279,6 +283,8 @@ diag_table:
             output_freq_units: days  # time units for output: years, months, days, hours, minutes, or seconds
         fields:
             eta_t:
+                auxiliary_fields:  # auxiliary fields to be included with this field
+                #     area_t:
             frazil_3d_int_z:
             mld:
             pme_river:

--- a/make_diag_table.py
+++ b/make_diag_table.py
@@ -154,6 +154,24 @@ for k, grp in indata['diag_table'].items():
                      f['regional_section'], f['packing']]
         outstrings.append(', '.join([strout(v) for v in fieldline]))
 
+        # Add any auxiliary fields to file, such as cell measures
+        if "auxiliary_fields" in f:
+            if f["auxiliary_fields"] is not None:
+                for aux_field_name, aux_field_dict in f["auxiliary_fields"].items():
+                    if aux_field_dict is None:
+                        aux_field_dict = {}
+                    # Allow changing name of auxiliary fields using "output_name" entry
+                    if "output_name" in aux_field_dict:
+                        aux_output_name = aux_field_dict["output_name"]
+                    else:
+                        aux_output_name = aux_field_name
+                    f_aux = {**f, **aux_field_dict}
+                    # Add auxiliary fields to same file as primary field
+                    auxline = [f_aux['module_name'], aux_field_name, aux_output_name,
+                        fname, f_aux['time_sampling'], f_aux['reduction_method'],
+                        f_aux['regional_section'], f_aux['packing']]
+                    outstrings.append(', '.join([strout(v) for v in auxline]))
+
 # output outstrings
 with open('diag_table', 'w') as f:
     for line in outstrings:

--- a/make_diag_table.py
+++ b/make_diag_table.py
@@ -155,14 +155,14 @@ for k, grp in indata['diag_table'].items():
         outstrings.append(', '.join([strout(v) for v in fieldline]))
 
         # Add any auxiliary fields to file, such as cell measures
-        if "auxiliary_fields" in f:
-            if f["auxiliary_fields"] is not None:
-                for aux_field_name, aux_field_dict in f["auxiliary_fields"].items():
+        if 'auxiliary_fields' in f:
+            if f['auxiliary_fields'] is not None:
+                for aux_field_name, aux_field_dict in f['auxiliary_fields'].items():
                     if aux_field_dict is None:
                         aux_field_dict = {}
-                    # Allow changing name of auxiliary fields using "output_name" entry
-                    if "output_name" in aux_field_dict:
-                        aux_output_name = aux_field_dict["output_name"]
+                    # Allow changing name of auxiliary fields using 'output_name' entry
+                    if 'output_name' in aux_field_dict:
+                        aux_output_name = aux_field_dict['output_name']
                     else:
                         aux_output_name = aux_field_name
                     f_aux = {**f, **aux_field_dict}


### PR DESCRIPTION
This PR allows adding optional "auxiliary fields" to each file. This is to address a limitation in FMS: in order to successfully request variables with "cell measures", the cell measure must be included in the _same_ file. Closes #13.

The PR adds an additional option for `"auxiliary_fields"`, which behave much like `fields`. They can be set globally for all files, for all variables within a section, or on a per-variable basis. Defaults for each entry in `auxiliary_fields` (e.g. `reduction_method` etc) can be overridden in the same way as for `fields`.

E.g., the following would add
- `aux1` to the file containing `var1` 
- `aux2` to the file containing `var2`
-  `aux3`, renamed to `auxiliary_variable_3` and with snapshot reduction, to the file containing `var3`

```yaml
global_defaults:
  auxiliary_fields:
    aux1:

diag_table:
  'Section 1':
    fields:
      var1:

  'Section 2':
    defaults:
      auxiliary_fields:
        aux2:
    fields:
      var2:
      var3:
        auxiliary_fields:
          aux3:
            output_name: auxiliary_variable_3
            reduction_method: snap
```